### PR TITLE
Use AudioWorklet for implementing a mixer node

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ There are no polyfill included in [the demo](https://kenrick95.github.io/nikku/)
 
 Browser needs to support the following features without any vendor prefix:
 
+- [Audio Worklet API](https://caniuse.com/mdn-api_audioworklet)
 - [Web Audio API](https://caniuse.com/#feat=audio-api)
 - [`<script type="module"> `](https://caniuse.com/#feat=es6-module)
 - [ES2016 class](https://caniuse.com/#feat=es6-class)

--- a/src/audioMixer.js
+++ b/src/audioMixer.js
@@ -1,0 +1,74 @@
+/**
+ * @typedef {import("./audioPlayer.js").AudioPlayerStreamStates} AudioPlayerStreamStates
+ */
+
+class AudioMixerProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    /**
+     * @type {AudioPlayerStreamStates}
+     */
+    this._streamStates = options.processorOptions.streamStates || {};
+    this.port.onmessage = (event) => {
+      if (event.data.streamStates) this.streamStates = event.data.streamStates;
+    };
+  }
+
+  /**
+   *
+   * @param {Array<Array<Float32Array>>} inputs
+   * @param {Array<Array<Float32Array>>} outputs
+   * @param {Object} _parameters
+   */
+  process(inputs, outputs, _parameters) {
+    const input = inputs[0];
+    const output = outputs[0];
+    if (!input) {
+      return false;
+    }
+    const channelCount = input.length;
+    if (!channelCount) {
+      return false;
+    }
+    const sampleCount = input[0].length;
+    if (!sampleCount) {
+      return false;
+    }
+
+    // let enabledChannelCount = 0;
+    // for (let channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+    //   if (
+    //     this._streamStates &&
+    //     this._streamStates[Math.floor(channelIndex / 2)]
+    //   ) {
+    //     enabledChannelCount++;
+    //   }
+    // }
+    for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
+      let sums = [0, 0];
+      for (let channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+        if (
+          this._streamStates &&
+          this._streamStates[Math.floor(channelIndex / 2)]
+        ) {
+          sums[channelIndex % 2] +=
+            input[Math.floor(channelIndex / 2)][sampleIndex];
+        }
+      }
+      /**
+       * NOTE: I initially thought I need to `sum[0] / enabledChannelCount`, but it makes the audio _really_ soft. 
+       * clamp()-ing the sum makes each channel still audible, with minimum distortion (I guess :?)
+       */
+      output[0][sampleIndex] = clamp(sums[0], -1, 1);
+      output[1][sampleIndex] = clamp(sums[1], -1, 1);
+    }
+
+    return true;
+  }
+}
+
+function clamp(value, min, max) {
+  return value <= min ? min : value >= max ? max : value;
+}
+
+registerProcessor('audio-mixer-processor', AudioMixerProcessor);

--- a/src/brstm/index.js
+++ b/src/brstm/index.js
@@ -616,7 +616,7 @@ export class Brstm {
           sampleIndex < totalSamplesInBlock;
           sampleIndex++
         ) {
-          sampleResult.push(getInt16(blockData[sampleIndex])*256);
+          sampleResult.push(getInt16(blockData[sampleIndex]) * 256);
         }
       } else {
         throw new Error('Invalid codec');

--- a/src/main.js
+++ b/src/main.js
@@ -78,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const allSamples = brstm.getAllSamples();
         console.timeEnd('brstm.getAllSamples');
 
+        await audioPlayer.readyPromise;
         audioPlayer.load(allSamples);
 
         elTime.removeAttribute('disabled');

--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const headerReader = new FileReader();
     headerReader.addEventListener('loadend', async (ev) => {
       try {
+        elErrors.textContent = '';
+
         const buffer = headerReader.result;
 
         const brstm = new Brstm(buffer);


### PR DESCRIPTION
An alternative solution is to downmix at load time, but it will mean that the full audio buffer need to be recomputed every time the stream states have changed. This may cause performance issue if the state changes happened a lot in a very short period

Fixes #19